### PR TITLE
Add a connection pool to RestEasy

### DIFF
--- a/src/main/java/com/codereligion/bugsnag/logback/Sender.java
+++ b/src/main/java/com/codereligion/bugsnag/logback/Sender.java
@@ -22,8 +22,8 @@ import com.codereligion.bugsnag.logback.resource.GsonProvider;
 import com.codereligion.bugsnag.logback.resource.NotifierResource;
 import com.google.gson.Gson;
 import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.core.Response;
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
 
 /**
@@ -134,8 +134,9 @@ public class Sender {
     private Client createClient() {
         final Gson gson = gsonProvider.getGson();
 
-        return ClientBuilder
-                .newClient()
-                .register(new GsonMessageBodyWriter(gson));
+        ResteasyClientBuilder clientBuilder = new ResteasyClientBuilder().connectionPoolSize(100);
+        return clientBuilder
+            .build()
+            .register(new GsonMessageBodyWriter(gson));
     }
 }


### PR DESCRIPTION
The current `ClientBuilder` does not use a connection pool, which means you can have only one parallel connection at a time. This sets up a reasonable connection pool to allow `bugsnag-logback` to better work in threaded environments.
