### PR TITLE
Remove Resteasy dependency so you can choose your own implementation.

### DIFF
--- a/src/main/java/com/codereligion/bugsnag/logback/Sender.java
+++ b/src/main/java/com/codereligion/bugsnag/logback/Sender.java
@@ -100,9 +100,9 @@ public class Sender {
         Response response = null;
 
         try {
-            final ResteasyWebTarget resteasyWebTarget = (ResteasyWebTarget) client.target(endpoint);
-            final NotifierResource notifierResource= resteasyWebTarget.proxy(NotifierResource.class);
-            response = notifierResource.sendNotification(notification);
+	    final WebTarget target = client.target(endpoint);
+            response = target.request(MediaType.APPLICATION_JSON).put(Entity.entity(notification,MediaType.APPLICATION_JSON));
+
             final int statusCode = response.getStatus();
 
             final boolean isOk = StatusCode.OK == statusCode;


### PR DESCRIPTION
Our project depends on a Apache CFX implementation of the JAX-RS API. Therefore this library conflicts since it uses Resteasy. By removing the Resteasy dependency we could compile again and use this library in our project.

*I'm not familiar with Resteasy so I don't now the consequences/drawbacks